### PR TITLE
Replace alias_method_chain with .prepend

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,7 +55,7 @@ honeypot protection, simply add the before filter for that action
 in your controller. For example:
 
     class NewsletterController < ApplicationController
-      prepend_before_filter :protect_from_spam, :only => [:subscribe]
+      prepend_before_action :protect_from_spam, :only => [:subscribe]
       ...
     end
 

--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -18,8 +18,8 @@ module HoneypotCaptcha
       base.send :helper_method, :honeypot_fields
       base.send :helper_method, :honeypot_string
 
-      if base.respond_to? :before_filter
-        base.send :prepend_before_filter, :protect_from_spam, :only => [:create, :update]
+      if base.respond_to? :before_action
+        base.send :prepend_before_action, :protect_from_spam, :only => [:create, :update]
       end
     end
   end

--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -1,40 +1,36 @@
 # Override the form_tag helper to add honeypot spam protection to forms.
-module ActionView
-  module Helpers
-    module FormTagHelper
-      module WithHoneypotFormTag
-        def form_tag_html(options)
-          honeypot = options.delete(:honeypot) || options.delete('honeypot')
-          html = super(options)
-          if honeypot
-            captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
-            if block_given?
-              html.insert(html.index('</form>'), captcha)
-            else
-              html += captcha
-            end
-          end
-          html
-        end
-
-        private
-
-        def honey_pot_captcha
-          html_ids = []
-          honeypot_fields.collect do |f, l|
-            html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
-            content_tag :div, :id => html_id do
-              content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
-                "#{html_ids.map {|i| "##{i}"}.join(', ')} { display:none; }"
-              end +
-                  label_tag(f, l) +
-                  send([:text_field_tag, :text_area_tag][rand(2)], f)
-            end
-          end.join
+module Honeypot
+  module FormTagHelper
+    def form_tag_html(options)
+      honeypot = options.delete(:honeypot) || options.delete('honeypot')
+      html = super(options)
+      if honeypot
+        captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
+        if block_given?
+          html.insert(html.index('</form>'), captcha)
+        else
+          html += captcha
         end
       end
+      html
+    end
 
-      self.prepend(WithHoneypotFormTag)
+    private
+
+    def honey_pot_captcha
+      html_ids = []
+      honeypot_fields.collect do |f, l|
+        html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
+        content_tag :div, :id => html_id do
+          content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
+            "#{html_ids.map {|i| "##{i}"}.join(', ')} { display:none; }"
+          end +
+              label_tag(f, l) +
+              send([:text_field_tag, :text_area_tag][rand(2)], f)
+        end
+      end.join
     end
   end
 end
+
+ActionView::Base.send(:prepend, Honeypot::FormTagHelper)

--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -2,36 +2,39 @@
 module ActionView
   module Helpers
     module FormTagHelper
-      def form_tag_html_with_honeypot(options)
-        honeypot = options.delete(:honeypot) || options.delete('honeypot')
-        html = form_tag_html_without_honeypot(options)
-        if honeypot
-          captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
-          if block_given?
-            html.insert(html.index('</form>'), captcha)
-          else
-            html += captcha
+      module WithHoneypotFormTag
+        def form_tag_html(options)
+          honeypot = options.delete(:honeypot) || options.delete('honeypot')
+          html = super(options)
+          if honeypot
+            captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
+            if block_given?
+              html.insert(html.index('</form>'), captcha)
+            else
+              html += captcha
+            end
           end
+          html
         end
-        html
-      end
-      alias_method_chain :form_tag_html, :honeypot
 
-    private
+        private
 
-      def honey_pot_captcha
-        html_ids = []
-        honeypot_fields.collect do |f, l|
-          html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
-          content_tag :div, :id => html_id do
-            content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
-              "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"
-            end +
-            label_tag(f, l) +
-            send([:text_field_tag, :text_area_tag][rand(2)], f)
-          end
-        end.join
+        def honey_pot_captcha
+          html_ids = []
+          honeypot_fields.collect do |f, l|
+            html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
+            content_tag :div, :id => html_id do
+              content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
+                "#{html_ids.map {|i| "##{i}"}.join(', ')} { display:none; }"
+              end +
+                  label_tag(f, l) +
+                  send([:text_field_tag, :text_area_tag][rand(2)], f)
+            end
+          end.join
+        end
       end
+
+      self.prepend(WithHoneypotFormTag)
     end
   end
 end


### PR DESCRIPTION
"alias_method_chain" does not exist in latest Rails 5.2

I still need to test this in the app, but haven't been able to load it yet since updating to 5.2 hehe